### PR TITLE
Added format options to fix 403 error

### DIFF
--- a/helpers/bot_client.py
+++ b/helpers/bot_client.py
@@ -27,6 +27,8 @@ ytdl_format_options = {
     'no_warnings': True,
     'default_search': 'auto',
     'source_address': '0.0.0.0',
+    'force-ipv4': True,
+    'cachedir': False,
 }
 ffmpeg_options = {
     'options': '-vn'


### PR DESCRIPTION
Referencing this thread on StackOverflow: https://stackoverflow.com/questions/70776710/i-get-too-often-the-http-error-403-forbidden-using-discord-py-and-ytdl